### PR TITLE
Modified namedb.py and annotate-seqs.py to work with files supplied via ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ mouse.protein.faa.psq
 petMar_lamp0.fasta
 petMar_lamp3.fasta
 petMar_mrna.lamp3.orig.fasta.gz
+/.project

--- a/annotate-seqs.py
+++ b/annotate-seqs.py
@@ -16,8 +16,6 @@ def main():
     parser.add_argument('transcripts')
     parser.add_argument('ortho')
     parser.add_argument('homol')
-    parser.add_argument('namedb')
-    parser.add_argument('dbFa')
     parser.add_argument('-z', '--no-ncbi', action='store_false',
                         dest='ncbi', default='True')
     args = parser.parse_args()

--- a/annotate-seqs.py
+++ b/annotate-seqs.py
@@ -16,6 +16,8 @@ def main():
     parser.add_argument('transcripts')
     parser.add_argument('ortho')
     parser.add_argument('homol')
+    parser.add_argument('namedb')
+    parser.add_argument('dbFa')
     parser.add_argument('-z', '--no-ncbi', action='store_false',
                         dest='ncbi', default='True')
     args = parser.parse_args()
@@ -37,7 +39,7 @@ def main():
 
         o = ortho.get(name)
         if o:
-            annot = namedb.mouse_names.get(transform_name(o, args.ncbi))
+            annot = namedb.data_names.get(transform_name(o, args.ncbi))
             tr_dict[tr] = ('ortho', annot)
         else:
             if tr in tr_dict and tr_dict[tr][0] == 'ortho':
@@ -52,7 +54,7 @@ def main():
 
                 h, score = h[0]
                 score = round(float(score) / float(len(record.sequence)) * 100)
-                annot = namedb.mouse_names[transform_name(h, args.ncbi)]
+                annot = namedb.data_names[transform_name(h, args.ncbi)]
 
                 if score > oldscore:
                     tr_dict[tr] = (oldscore, annot)
@@ -76,7 +78,7 @@ def main():
 
         o = ortho.get(name)
         if o:
-            annot = namedb.mouse_names.get(transform_name(o, args.ncbi))
+            annot = namedb.data_names.get(transform_name(o, args.ncbi))
             annot = "ortho:" + annot
             annot_ortho_count += 1
         else:
@@ -85,7 +87,7 @@ def main():
             if h:
                 h, score = h[0]
                 score = round(float(score) / float(len(record.sequence)) * 100)
-                annot = namedb.mouse_names[transform_name(h, args.ncbi)]
+                annot = namedb.data_names[transform_name(h, args.ncbi)]
                 annot = "h=%d%% => " % score + annot
                 annot += " "
                 annot_homol_count += 1

--- a/make-namedb.py
+++ b/make-namedb.py
@@ -6,10 +6,11 @@ import sys
 
 # the name-db
 outfile = "names.db"
+seqFile = sys.argv[1]
 
 d = {}
 e = {}
-for record in screed.open(sys.argv[1]):
+for record in screed.open(seqFile):
     if record.name.startswith('gi|'):
        ident = record.name.split('|')[3]
     else:
@@ -18,7 +19,8 @@ for record in screed.open(sys.argv[1]):
     e[ident] = record.name
 
 fp = open(outfile, 'w')
-dump(dict(seqs=sys.argv[1],names=d), fp)
+dump(seqFile, fp)
+dump(d,fp)
 
 fp = open('fullnames.db', 'w')
 dump(e, fp)

--- a/make-namedb.py
+++ b/make-namedb.py
@@ -4,7 +4,8 @@ from cPickle import dump
 import screed
 import sys
 
-outfile = sys.argv[2]
+# the name-db
+outfile = "names.db"
 
 d = {}
 e = {}
@@ -17,7 +18,7 @@ for record in screed.open(sys.argv[1]):
     e[ident] = record.name
 
 fp = open(outfile, 'w')
-dump(d, fp)
+dump(dict(seqs=sys.argv[1],names=d), fp)
 
-fp = open(outfile + '.fullname', 'w')
+fp = open('fullnames.db', 'w')
 dump(e, fp)

--- a/namedb.py
+++ b/namedb.py
@@ -1,8 +1,6 @@
 import cPickle
 import screed
 
-data = cPickle.load('names.db')
-
-data_names = data.get('names',[])
+data_names = cPickle.load('names.db')
 data_fullname = cPickle.load(open('fullnames.db'))
-data_seqs = screed.ScreedDB(data.get('seqs'),[])
+data_seqs = screed.ScreedDB(cPickle.load('names.db'))

--- a/namedb.py
+++ b/namedb.py
@@ -1,7 +1,8 @@
 import cPickle
 import screed
 
-data_names = cPickle.load(open(sys.argv[4]))
-fullname = "%s.fullname" % sys.argv[4]
-data_fullname = cPickle.load(open(fullname))
-data_seqs = screed.ScreedDB(sys.argv[5])
+data = cPickle.load('names.db')
+
+data_names = data.get('names',[])
+data_fullname = cPickle.load(open('fullnames.db'))
+data_seqs = screed.ScreedDB(data.get('seqs'),[])

--- a/namedb.py
+++ b/namedb.py
@@ -1,6 +1,7 @@
 import cPickle
 import screed
 
-mouse_names = cPickle.load(open('mouse.namedb'))
-mouse_fullname = cPickle.load(open('mouse.namedb.fullname'))
-mouse_seqs = screed.ScreedDB('mouse.protein.faa')
+data_names = cPickle.load(open(sys.argv[4]))
+fullname = "%s.fullname" % sys.argv[4]
+data_fullname = cPickle.load(open(fullname))
+data_seqs = screed.ScreedDB(sys.argv[5])


### PR DESCRIPTION
...command line to annotate-seqs.py

mouse.namedb, mouse.namedb.fullname and mouse.protein.faa were hardcoded into namedb.py.
Now, it picks up from sys.argv[4] and sys.argv[5], where sys.argv is supplied to
annotate-seqs.py

Possible regression bugs if namedb.py is used by scripts other than annotate-seqs.py
that use a different command line argument pattern
